### PR TITLE
[JENKINS-30133] Workflow compatibility

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -66,7 +66,6 @@
             <groupId>org.jvnet.hudson.plugins</groupId>
             <artifactId>analysis-core</artifactId>
             <version>1.73-beta-SNAPSHOT</version><!-- TODO: change to 1.73 before release -->
-            <type>hpi</type>
         </dependency>
         <dependency>
             <groupId>org.jvnet.hudson.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -4,9 +4,7 @@
 	<parent>
         <groupId>org.jvnet.hudson.plugins</groupId>
         <artifactId>analysis-pom</artifactId>
-        <version>1.59</version><!-- which version of Jenkins is this plugin built 
-            against? -->
-        <relativePath>../analysis-pom/pom.xml</relativePath>
+        <version>1.63</version><!-- Jenkins 1.596.1 -->
 	</parent>
 
 	<inceptionYear>2010</inceptionYear>
@@ -67,7 +65,7 @@
         <dependency>
             <groupId>org.jvnet.hudson.plugins</groupId>
             <artifactId>analysis-core</artifactId>
-            <version>1.71</version>
+            <version>1.73-beta-SNAPSHOT</version><!-- TODO: change to 1.73 before release -->
             <type>hpi</type>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -40,6 +40,10 @@
 		</repository>
 	</distributionManagement>
 
+    <properties>
+        <workflow.version>1.7</workflow.version>
+    </properties>
+
 	<developers>
 		<developer>
 			<email>brunodepaulak@yahoo.com.br</email>
@@ -71,6 +75,24 @@
             <groupId>org.jvnet.hudson.plugins</groupId>
             <artifactId>analysis-test</artifactId>
             <version>1.12</version>
+        </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins.workflow</groupId>
+            <artifactId>workflow-job</artifactId>
+            <version>${workflow.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins.workflow</groupId>
+            <artifactId>workflow-cps</artifactId>
+            <version>${workflow.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins.workflow</groupId>
+            <artifactId>workflow-basic-steps</artifactId>
+            <version>${workflow.version}</version>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 

--- a/src/main/java/hudson/plugins/ccm/CcmReporterResult.java
+++ b/src/main/java/hudson/plugins/ccm/CcmReporterResult.java
@@ -24,6 +24,7 @@
 package hudson.plugins.ccm;
 
 import hudson.model.AbstractBuild;
+import hudson.model.Run;
 import hudson.plugins.analysis.core.BuildResult;
 import hudson.plugins.analysis.core.ParserResult;
 import hudson.plugins.analysis.core.ResultAction;
@@ -43,7 +44,7 @@ public class CcmReporterResult extends CcmResult {
 	 * @param defaultEncoding
 	 * @param result
 	 */
-	public CcmReporterResult(AbstractBuild<?, ?> build, String defaultEncoding,
+	public CcmReporterResult(Run<?, ?> build, String defaultEncoding,
 			ParserResult result) {
 		super(build, defaultEncoding, result);
 	}

--- a/src/main/java/hudson/plugins/ccm/CcmResult.java
+++ b/src/main/java/hudson/plugins/ccm/CcmResult.java
@@ -23,7 +23,7 @@
  */
 package hudson.plugins.ccm;
 
-import hudson.model.AbstractBuild;
+import hudson.model.Run;
 import hudson.plugins.analysis.core.BuildHistory;
 import hudson.plugins.analysis.core.BuildResult;
 import hudson.plugins.analysis.core.ParserResult;
@@ -44,8 +44,8 @@ public class CcmResult extends BuildResult {
 	 * @param defaultEncoding
 	 * @param result
 	 */
-	public CcmResult(final AbstractBuild<?, ?> build, final String defaultEncoding, final ParserResult result) {
-		super(build, defaultEncoding, result, new BuildHistory(build, CcmResultAction.class));
+	public CcmResult(final Run<?, ?> build, final String defaultEncoding, final ParserResult result) {
+		super(build, new BuildHistory(build, CcmResultAction.class, false, false), result, defaultEncoding);
 	}
 	
 	/* (non-Javadoc)

--- a/src/main/java/hudson/plugins/ccm/CcmResult.java
+++ b/src/main/java/hudson/plugins/ccm/CcmResult.java
@@ -46,6 +46,7 @@ public class CcmResult extends BuildResult {
 	 */
 	public CcmResult(final Run<?, ?> build, final String defaultEncoding, final ParserResult result) {
 		super(build, new BuildHistory(build, CcmResultAction.class, false, false), result, defaultEncoding);
+		serializeAnnotations(result.getAnnotations());
 	}
 	
 	/* (non-Javadoc)

--- a/src/main/java/hudson/plugins/ccm/CcmResultAction.java
+++ b/src/main/java/hudson/plugins/ccm/CcmResultAction.java
@@ -24,6 +24,7 @@
 package hudson.plugins.ccm;
 
 import hudson.model.AbstractBuild;
+import hudson.model.Run;
 import hudson.plugins.analysis.core.AbstractResultAction;
 import hudson.plugins.analysis.core.HealthDescriptor;
 import hudson.plugins.analysis.core.PluginDescriptor;
@@ -47,7 +48,7 @@ public class CcmResultAction extends AbstractResultAction<CcmResult> {
 	 * @param healthDescriptor
 	 * @param result
 	 */
-	public CcmResultAction(final AbstractBuild<?, ?> owner, final HealthDescriptor healthDescriptor, final CcmResult result) {
+	public CcmResultAction(final Run<?, ?> owner, final HealthDescriptor healthDescriptor, final CcmResult result) {
 		super(owner, new CcmHealthDescriptor(healthDescriptor), result);
 	}
 	
@@ -55,8 +56,8 @@ public class CcmResultAction extends AbstractResultAction<CcmResult> {
 	 * @param owner
 	 * @param healthDescriptor
 	 */
-	public CcmResultAction(AbstractBuild<?, ?> owner, final HealthDescriptor healthDescriptor) {
-		super(owner, new CcmHealthDescriptor(healthDescriptor));
+	public CcmResultAction(Run<?, ?> owner, final HealthDescriptor healthDescriptor) {
+		super(owner, new CcmHealthDescriptor(healthDescriptor), null);
 	}
 
 	/* (non-Javadoc)

--- a/src/test/java/hudson/plugins/ccm/workflow/WorkflowCompatibilityTest.java
+++ b/src/test/java/hudson/plugins/ccm/workflow/WorkflowCompatibilityTest.java
@@ -1,0 +1,79 @@
+package hudson.plugins.ccm.workflow;
+
+import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
+import org.jenkinsci.plugins.workflow.job.WorkflowJob;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+
+import hudson.FilePath;
+
+import hudson.model.Result;
+import hudson.plugins.ccm.CcmResultAction;
+
+import static org.junit.Assert.*;
+
+/**
+ * Test workflow compatibility.
+ */
+public class WorkflowCompatibilityTest {
+
+    @ClassRule
+    public static JenkinsRule j = new JenkinsRule();
+
+    /**
+     * Run a workflow job using {@link CcmPublisher} and check for success.
+     */
+    @Test
+    public void ccmPublisherWorkflowStep() throws Exception {
+        WorkflowJob job = j.jenkins.createProject(WorkflowJob.class, "wf");
+        FilePath workspace = j.jenkins.getWorkspaceFor(job);
+        FilePath report = workspace.child("target").child("ccm.cs");
+        report.copyFrom(WorkflowCompatibilityTest.class.getResourceAsStream("/hudson/plugins/ccm/parser/ccm.result.xml"));
+        job.setDefinition(new CpsFlowDefinition(
+        "node {" +
+        "  step([$class: 'CcmPublisher'])" +
+        "}"));
+        j.assertBuildStatusSuccess(job.scheduleBuild2(0));
+        CcmResultAction result = job.getLastBuild().getAction(CcmResultAction.class);
+        assertEquals(22, result.getResult().getAnnotations().size());
+    }
+
+    /**
+     * Run a workflow job using {@link CcmPublisher} with a failing threshols of 0, so the given example file
+     * "/hudson/plugins/ccm/parser/ccm.result.xml" will make the build to fail.
+     */
+    @Test
+    public void ccmPublisherWorkflowStepSetLimits() throws Exception {
+        WorkflowJob job = j.jenkins.createProject(WorkflowJob.class, "wf2");
+        FilePath workspace = j.jenkins.getWorkspaceFor(job);
+        FilePath report = workspace.child("target").child("ccm.test.xml");
+        report.copyFrom(WorkflowCompatibilityTest.class.getResourceAsStream("/hudson/plugins/ccm/parser/ccm.result.xml"));
+        job.setDefinition(new CpsFlowDefinition(
+        "node {" +
+        "  step([$class: 'CcmPublisher', pattern: '**/ccm.test.xml', failedTotalAll: '0', usePreviousBuildAsReference: false])" +
+        "}"));
+        j.assertBuildStatus(Result.FAILURE, job.scheduleBuild2(0).get());
+        CcmResultAction result = job.getLastBuild().getAction(CcmResultAction.class);
+        assertEquals(22, result.getResult().getAnnotations().size());
+    }
+
+    /**
+     * Run a workflow job using {@link CcmPublisher} with a unstable threshols of 0, so the given example file
+     * "/hudson/plugins/ccm/parser/ccm.result.xml" will make the build to fail.
+     */
+    @Test
+    public void ccmPublisherWorkflowStepFailure() throws Exception {
+        WorkflowJob job = j.jenkins.createProject(WorkflowJob.class, "wf3");
+        FilePath workspace = j.jenkins.getWorkspaceFor(job);
+        FilePath report = workspace.child("target").child("ccm.xml");
+        report.copyFrom(WorkflowCompatibilityTest.class.getResourceAsStream("/hudson/plugins/ccm/parser/ccm.result.xml"));
+        job.setDefinition(new CpsFlowDefinition(
+        "node {" +
+        "  step([$class: 'CcmPublisher', pattern: '**/ccm.xml', unstableTotalAll: '0', usePreviousBuildAsReference: false])" +
+        "}"));
+        j.assertBuildStatus(Result.UNSTABLE, job.scheduleBuild2(0).get());
+        CcmResultAction result = job.getLastBuild().getAction(CcmResultAction.class);
+        assertEquals(22, result.getResult().getAnnotations().size());
+    }
+}


### PR DESCRIPTION
Downstream of https://github.com/jenkinsci/analysis-core-plugin/pull/31

[JENKINS-30133](https://issues.jenkins-ci.org/browse/JENKINS-30133)

This changes allow to use ```CcmPublisher``` in a Workflow script, for example:

```
node {
  step([$class: 'CcmPublisher', pattern: '**/ccm.xml', failedTotalAll: '0', usePreviousBuildAsReference: false])
}
```